### PR TITLE
Interface prefix is now configurable and defaults to ""

### DIFF
--- a/typescript-service-generator-core/src/main/java/com/palantir/code/ts/generator/ServiceEmitter.java
+++ b/typescript-service-generator-core/src/main/java/com/palantir/code/ts/generator/ServiceEmitter.java
@@ -82,12 +82,13 @@ public final class ServiceEmitter {
 
     public void emitTypescriptClass() {
         writer.writeLine("");
-        writer.writeLine("export class " + model.name() + " implements " + settings.getSettings().addTypeNamePrefix + model.name() + " {");
+        // Adding "Impl" ensures the class name is different from the impl name, which is a compilation requirement.
+        writer.writeLine("export class " + model.name() + "Impl" + " implements " + settings.getSettings().addTypeNamePrefix + model.name() + " {");
         writer.increaseIndent();
 
         writer.writeLine("");
-        writer.writeLine("private httpApiBridge: IHttpApiBridge;");
-        writer.writeLine("constructor(httpApiBridge: IHttpApiBridge) {");
+        writer.writeLine(String.format("private httpApiBridge: %sHttpApiBridge;", settings.generatedInterfacePrefix()));
+        writer.writeLine(String.format("constructor(httpApiBridge: %sHttpApiBridge) {", settings.generatedInterfacePrefix()));
         writer.increaseIndent();
         writer.writeLine("this.httpApiBridge = httpApiBridge;");
         writer.decreaseIndent();
@@ -100,7 +101,7 @@ public final class ServiceEmitter {
             line += ") {";
             writer.writeLine(line);
             writer.increaseIndent();
-            writer.writeLine("var httpCallData = <IHttpEndpointOptions> {");
+            writer.writeLine(String.format("var httpCallData = <%sHttpEndpointOptions> {", settings.generatedInterfacePrefix()));
             writer.increaseIndent();
             writer.writeLine("serviceIdentifier: \"" + Character.toLowerCase(model.name().charAt(0)) + model.name().substring(1) + "\",");
             writer.writeLine("endpointPath: \"" + getEndpointPathString(model, endpointModel) + "\",");

--- a/typescript-service-generator-core/src/main/java/com/palantir/code/ts/generator/ServiceGenerator.java
+++ b/typescript-service-generator-core/src/main/java/com/palantir/code/ts/generator/ServiceGenerator.java
@@ -41,7 +41,8 @@ public final class ServiceGenerator {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        bridgeFileLines = Lists.newArrayList(String.format(Joiner.on(settings.getSettings().newline).join(bridgeFileLines), String.format(settings.genericEndpointReturnType(), "T")).split("\n"));
+        String generatedInterfacePrefix = settings.generatedInterfacePrefix();
+        bridgeFileLines = Lists.newArrayList(String.format(Joiner.on(settings.getSettings().newline).join(bridgeFileLines), generatedInterfacePrefix, generatedInterfacePrefix, generatedInterfacePrefix, String.format(settings.genericEndpointReturnType(), "T")).split("\n"));
         for (String line : bridgeFileLines) {
             writer.writeLine(line);
         }

--- a/typescript-service-generator-core/src/main/java/com/palantir/code/ts/generator/TypescriptServiceGeneratorConfiguration.java
+++ b/typescript-service-generator-core/src/main/java/com/palantir/code/ts/generator/TypescriptServiceGeneratorConfiguration.java
@@ -96,6 +96,14 @@ public abstract class TypescriptServiceGeneratorConfiguration {
     @Value.Parameter
     public abstract File generatedFolderLocation();
 
+    /**
+     * The prefix to put before all generated interfaces.
+     */
+    @Value.Default
+    public String generatedInterfacePrefix() {
+        return "";
+    }
+
     public TypeProcessor getOverridingTypeParser() {
         TypeProcessor defaultTypeProcessor = new TypeProcessor() {
             @Override
@@ -133,7 +141,7 @@ public abstract class TypescriptServiceGeneratorConfiguration {
         typeProcessors.add(getOverridingTypeParser());
         typeProcessors.add(genericTypeProcessor);
         settings.customTypeProcessor = new TypeProcessor.Chain(typeProcessors);
-        settings.addTypeNamePrefix = "I";
+        settings.addTypeNamePrefix = generatedInterfacePrefix();
         settings.sortDeclarations = true;
         settings.noFileComment = true;
 

--- a/typescript-service-generator-core/src/main/resources/httpApiBridge.ts
+++ b/typescript-service-generator-core/src/main/resources/httpApiBridge.ts
@@ -1,4 +1,4 @@
-export interface IHttpEndpointOptions {
+export interface %sHttpEndpointOptions {
     serviceIdentifier?: string;
     endpointPath: string;
     method: string;
@@ -9,6 +9,6 @@ export interface IHttpEndpointOptions {
     data?: any;
 }
 
-export interface IHttpApiBridge {
-    callEndpoint<T>(parameters: IHttpEndpointOptions): %s;
+export interface %sHttpApiBridge {
+    callEndpoint<T>(parameters: %sHttpEndpointOptions): %s;
 }

--- a/typescript-service-generator-core/src/test/java/com/palantir/code/ts/generator/ServiceEmitterTest.java
+++ b/typescript-service-generator-core/src/test/java/com/palantir/code/ts/generator/ServiceEmitterTest.java
@@ -47,16 +47,16 @@ public class ServiceEmitterTest {
         writer.close();
         String expectedOutput = "" +
 "\n" +
-"    export interface IDataObject {\n" +
-"        y: IMyObject;\n" +
+"    export interface DataObject {\n" +
+"        y: MyObject;\n" +
 "    }\n" +
 "\n" +
-"    export interface IGenericObject<T> {\n" +
+"    export interface GenericObject<T> {\n" +
 "        y: T;\n" +
 "    }\n" +
 "\n" +
-"    export interface IMyObject {\n" +
-"        y: IMyObject;\n" +
+"    export interface MyObject {\n" +
+"        y: MyObject;\n" +
 "    }\n" +
 "";
         assertEquals(expectedOutput, new String(stream.toByteArray()));
@@ -69,10 +69,10 @@ public class ServiceEmitterTest {
         serviceEmitter.emitTypescriptInterface();
         writer.close();
         String expectedOutput = "\n" +
-"export interface ITestComplexServiceClass {\n" +
-"    allOptionsPost(a: string, dataObject: IDataObject, x?: number): FooType<IGenericObject<IMyObject>>;\n" +
-"    queryGetter(x?: boolean): FooType<IMyObject>;\n" +
-"    simplePut(dataObject: IDataObject): FooType<string>;\n" +
+"export interface TestComplexServiceClass {\n" +
+"    allOptionsPost(a: string, dataObject: DataObject, x?: number): FooType<GenericObject<MyObject>>;\n" +
+"    queryGetter(x?: boolean): FooType<MyObject>;\n" +
+"    simplePut(dataObject: DataObject): FooType<string>;\n" +
 "}\n";
         assertEquals(expectedOutput, new String(stream.toByteArray()));
     }
@@ -84,15 +84,15 @@ public class ServiceEmitterTest {
         serviceEmitter.emitTypescriptClass();
         writer.close();
         String expectedOutput = "\n" +
-"export class TestComplexServiceClass implements ITestComplexServiceClass {\n" +
+"export class TestComplexServiceClassImpl implements TestComplexServiceClass {\n" +
 "\n" +
-"    private httpApiBridge: IHttpApiBridge;\n" +
-"    constructor(httpApiBridge: IHttpApiBridge) {\n" +
+"    private httpApiBridge: HttpApiBridge;\n" +
+"    constructor(httpApiBridge: HttpApiBridge) {\n" +
 "        this.httpApiBridge = httpApiBridge;\n" +
 "    }\n" +
 "\n" +
-"    public allOptionsPost(a: string, dataObject: IDataObject, x?: number) {\n" +
-"        var httpCallData = <IHttpEndpointOptions> {\n" +
+"    public allOptionsPost(a: string, dataObject: DataObject, x?: number) {\n" +
+"        var httpCallData = <HttpEndpointOptions> {\n" +
 "            serviceIdentifier: \"testComplexServiceClass\",\n" +
 "            endpointPath: \"testComplexService/allOptionsPost/{a}\",\n" +
 "            method: \"POST\",\n" +
@@ -104,11 +104,11 @@ public class ServiceEmitterTest {
 "            },\n" +
 "            data: dataObject\n" +
 "        };\n" +
-"        return this.httpApiBridge.callEndpoint<IGenericObject<IMyObject>>(httpCallData);\n" +
+"        return this.httpApiBridge.callEndpoint<GenericObject<MyObject>>(httpCallData);\n" +
 "    }\n" +
 "\n" +
 "    public queryGetter(x?: boolean) {\n" +
-"        var httpCallData = <IHttpEndpointOptions> {\n" +
+"        var httpCallData = <HttpEndpointOptions> {\n" +
 "            serviceIdentifier: \"testComplexServiceClass\",\n" +
 "            endpointPath: \"testComplexService/queryGetter\",\n" +
 "            method: \"GET\",\n" +
@@ -120,11 +120,11 @@ public class ServiceEmitterTest {
 "            },\n" +
 "            data: null\n" +
 "        };\n" +
-"        return this.httpApiBridge.callEndpoint<IMyObject>(httpCallData);\n" +
+"        return this.httpApiBridge.callEndpoint<MyObject>(httpCallData);\n" +
 "    }\n" +
 "\n" +
-"    public simplePut(dataObject: IDataObject) {\n" +
-"        var httpCallData = <IHttpEndpointOptions> {\n" +
+"    public simplePut(dataObject: DataObject) {\n" +
+"        var httpCallData = <HttpEndpointOptions> {\n" +
 "            serviceIdentifier: \"testComplexServiceClass\",\n" +
 "            endpointPath: \"testComplexService/simplePut\",\n" +
 "            method: \"PUT\",\n" +

--- a/typescript-service-generator-core/src/test/java/com/palantir/code/ts/generator/ServiceGeneratorEteTest.java
+++ b/typescript-service-generator-core/src/test/java/com/palantir/code/ts/generator/ServiceGeneratorEteTest.java
@@ -31,6 +31,7 @@ public class ServiceGeneratorEteTest {
                                                                                                                   .generatedMessage("// Generated")
                                                                                                                   .generatedFolderLocation(actualDirectory)
                                                                                                                   .genericEndpointReturnType("FooReturn<%s>")
+                                                                                                                  .generatedInterfacePrefix("I")
                                                                                                                   .typescriptModule("ModuleName")
                                                                                                                   .build();
         ServiceGenerator serviceGenerator = new ServiceGenerator(config);

--- a/typescript-service-generator-core/src/test/resources/eteTestData/complexServiceTestOutput/testComplexServiceClass.ts
+++ b/typescript-service-generator-core/src/test/resources/eteTestData/complexServiceTestOutput/testComplexServiceClass.ts
@@ -20,7 +20,7 @@ module ModuleName.TestComplexServiceClass {
         simplePut(dataObject: IDataObject): FooReturn<string>;
     }
 
-    export class TestComplexServiceClass implements ITestComplexServiceClass {
+    export class TestComplexServiceClassImpl implements ITestComplexServiceClass {
 
         private httpApiBridge: IHttpApiBridge;
         constructor(httpApiBridge: IHttpApiBridge) {

--- a/typescript-service-generator-examples/exampleTypescript/generated/myService.ts
+++ b/typescript-service-generator-examples/exampleTypescript/generated/myService.ts
@@ -10,7 +10,7 @@ module MyProject.Http.MyService {
         helloWorld(): ng.IPromise<IMyObject>;
     }
 
-    export class MyService implements IMyService {
+    export class MyServiceImpl implements IMyService {
 
         private httpApiBridge: IHttpApiBridge;
         constructor(httpApiBridge: IHttpApiBridge) {

--- a/typescript-service-generator-examples/src/main/java/com/palantir/code/ts/generator/examples/MyServiceGenerator.java
+++ b/typescript-service-generator-examples/src/main/java/com/palantir/code/ts/generator/examples/MyServiceGenerator.java
@@ -23,6 +23,7 @@ public class MyServiceGenerator {
         builder.generatedFolderLocation(new File(generatedFolderPath));
         // This example targets angular, angular $http returns ng.IPromise<%s> so we target that return type here
         builder.genericEndpointReturnType("ng.IPromise<%s>");
+        builder.generatedInterfacePrefix("I");
 
         ServiceGenerator generator = new ServiceGenerator(builder.build());
         generator.generateTypescriptService(MyService.class);


### PR DESCRIPTION
Creates a backcompat break, the generated classes now have "Impl"
suffixed to guarantee a unique name