### PR TITLE
Expose optional annotations in TypescriptServiceGeneratorConfiguration

### DIFF
--- a/typescript-service-generator-core/src/main/java/com/palantir/code/ts/generator/TypescriptServiceGeneratorConfiguration.java
+++ b/typescript-service-generator-core/src/main/java/com/palantir/code/ts/generator/TypescriptServiceGeneratorConfiguration.java
@@ -5,6 +5,7 @@
 package com.palantir.code.ts.generator;
 
 import java.io.File;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -92,7 +93,7 @@ public abstract class TypescriptServiceGeneratorConfiguration {
     public boolean emitES6() {
     	return false;
     }
-    
+
     /**
      * A Java format string, expected to have exactly one %s where a generic should be placed.
      * Specifies what return types should look like.
@@ -109,6 +110,14 @@ public abstract class TypescriptServiceGeneratorConfiguration {
     @Value.Default
     public Set<Class<?>> ignoredAnnotations() {
         return new HashSet<>();
+    }
+
+    /**
+     * A list of annotations that will generate fields as optional in the typescript definitions.
+     */
+    @Value.Default
+    public List<Class<? extends Annotation>> optionalAnnotations() {
+        return new ArrayList<>();
     }
 
     /**
@@ -201,6 +210,7 @@ public abstract class TypescriptServiceGeneratorConfiguration {
         settings.sortDeclarations = true;
         settings.noFileComment = true;
         settings.jsonLibrary = JsonLibrary.jackson2;
+        settings.optionalAnnotations = optionalAnnotations();
         settings.outputKind = TypeScriptOutputKind.global;
         settings.outputFileType = TypeScriptFileType.implementationFile;
         settings.extensions = Lists.newArrayList(new EnumConstantsExtension());

--- a/typescript-service-generator-core/src/main/java/com/palantir/code/ts/generator/TypescriptServiceGeneratorConfiguration.java
+++ b/typescript-service-generator-core/src/main/java/com/palantir/code/ts/generator/TypescriptServiceGeneratorConfiguration.java
@@ -16,6 +16,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -116,8 +119,9 @@ public abstract class TypescriptServiceGeneratorConfiguration {
      * A list of annotations that will generate fields as optional in the typescript definitions.
      */
     @Value.Default
+    @SuppressWarnings("unchecked")
     public List<Class<? extends Annotation>> optionalAnnotations() {
-        return new ArrayList<>();
+        return Lists.newArrayList(CheckForNull.class, Nullable.class);
     }
 
     /**


### PR DESCRIPTION
Based on this commit in typescript-generator: https://github.com/vojtechhabarta/typescript-generator/commit/cf55f22094adab8bfefbda084d5a6969e3e0ba5c