### PR TITLE
Fixing bug when service classes had no path specified

### DIFF
--- a/typescript-service-generator-core/src/main/java/com/palantir/code/ts/generator/ServiceClassParser.java
+++ b/typescript-service-generator-core/src/main/java/com/palantir/code/ts/generator/ServiceClassParser.java
@@ -72,7 +72,7 @@ public final class ServiceClassParser {
         for (Class<?> serviceClass : serviceClazzes) {
             ImmutableInnerServiceModel.Builder innerServiceModel = ImmutableInnerServiceModel.builder();
             Path servicePathAnnotation = serviceClass.getAnnotation(Path.class);
-            innerServiceModel.servicePath(PathUtils.trimSlashes(servicePathAnnotation.value()));
+            innerServiceModel.servicePath(servicePathAnnotation == null ? "" : PathUtils.trimSlashes(servicePathAnnotation.value()));
             innerServiceModel.name(serviceClass.getSimpleName());
 
             Set<Method> serviceMethods = getAllServiceMethods(serviceClass, settings.methodFilter());

--- a/typescript-service-generator-core/src/test/java/com/palantir/code/ts/generator/ServiceClassParserTest.java
+++ b/typescript-service-generator-core/src/test/java/com/palantir/code/ts/generator/ServiceClassParserTest.java
@@ -35,6 +35,7 @@ import com.palantir.code.ts.generator.model.InnerServiceModel;
 import com.palantir.code.ts.generator.model.ServiceEndpointModel;
 import com.palantir.code.ts.generator.model.ServiceEndpointParameterModel;
 import com.palantir.code.ts.generator.model.ServiceModel;
+import com.palantir.code.ts.generator.utils.TestUtils;
 import com.palantir.code.ts.generator.utils.TestUtils.DataObject;
 import com.palantir.code.ts.generator.utils.TestUtils.DuplicateMethodNamesService;
 import com.palantir.code.ts.generator.utils.TestUtils.GenericObject;
@@ -290,4 +291,12 @@ public class ServiceClassParserTest {
         assertEquals(expectedServiceModel, model);
     }
 
+    @Test
+    public void noServiceClassPathTest() {
+        ServiceModel model = serviceClassParser.parseServiceClass(TestUtils.NoPathService.class, settings);
+
+        assertEquals(1, model.innerServiceModels().size());
+        assertEquals(1, model.innerServiceModels().get(0).endpointModels().size());
+        assertEquals("", model.innerServiceModels().get(0).servicePath());
+    }
 }

--- a/typescript-service-generator-core/src/test/java/com/palantir/code/ts/generator/utils/TestUtils.java
+++ b/typescript-service-generator-core/src/test/java/com/palantir/code/ts/generator/utils/TestUtils.java
@@ -115,6 +115,13 @@ public class TestUtils {
         public String plainText(String dataBody);
     }
 
+    public interface NoPathService {
+
+        @GET
+        @Path("foo")
+        public String foo();
+    }
+
     public enum MyEnum {
         VALUE1, VALUE2
     }


### PR DESCRIPTION
Correct behavior is to default to the empty path